### PR TITLE
fix(#52): add chapter JSON array to cover

### DIFF
--- a/app/Http/Controllers/Api/V1/ChapterController.php
+++ b/app/Http/Controllers/Api/V1/ChapterController.php
@@ -3,18 +3,22 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\DeleteChapterRequest;
 use App\Http\Requests\Api\V1\IndexChapterRequest;
+use App\Http\Requests\Api\V1\ShowChapterRequest;
 use App\Http\Requests\Api\V1\StoreChapterRequest;
 use App\Http\Requests\Api\V1\UpdateChapterRequest;
 use App\Http\Resources\V1\ChapterCollection;
 use App\Http\Resources\V1\ChapterResource;
 use App\Models\Chapter;
+use App\Models\Cover;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @group Chapters APIs
- * 
+ *
  * APIs for managing chapters.
- * 
+ *
  * @authenticated
  */
 class ChapterController extends Controller
@@ -23,38 +27,62 @@ class ChapterController extends Controller
      * Retrieve all chapters associated with a specific cover.
      *
      * @queryParam coverId integer required The ID of the cover this chapter is associated with.
+     *
+     * @response 200 {"data":[{"id":1,"title":"New book 1","public":false,"blockIds":[]},{"id":2,"title":"new Book 2","public":false,"blockIds":[]},{"id":3,"title":"new 3","public":true,"blockIds":[]},{"id":8,"title":"new chapter yes","public":false,"blockIds":[]},{"id":9,"title":"new chapter yes","public":false,"blockIds":[]},{"id":10,"title":"new chapter yes","public":false,"blockIds":[]},{"id":11,"title":"new chapter yes","public":false,"blockIds":[]},{"id":12,"title":"new chapter yes","public":false,"blockIds":[]}]}
+     * @response 404 {"message":"The selected cover id is invalid.","errors":{"coverId":["The selected cover id is invalid."]}}
      */
     public function index(IndexChapterRequest $request)
     {
-        return new ChapterCollection(Chapter::where('cover_id', $request->coverId)->get());
+        $cover = Cover::where('cover_id', $request->coverId)->first();
+
+        return new ChapterCollection($cover->chapters());
     }
 
     /**
-     * Create a new chapter.
-     * 
+     * Append a new chapter to the end of an array.
+     *
      * @bodyParam title string required The title of the chapter.
      * @bodyParam coverId integer required The ID of the cover this chapter is associated with.
      */
     public function store(StoreChapterRequest $request)
     {
-        return new ChapterResource(Chapter::create($request->all()));
+        $chapter = DB::transaction(function () use ($request) {
+            $cover = Cover::where('cover_id', $request->cover_id)->first();
+            $chapter = Chapter::create($request->all());
+            $cover->appendChapter($chapter);
+            $cover->save();
+
+            return $chapter;
+        });
+
+        return new ChapterResource($chapter);
     }
 
     /**
      * Get a chapter by its ID.
-     * 
-     * @urlparam id integer required The ID of the chapter.
+     *
+     * @urlParam id integer required The ID of the chapter.
+     *
+     * @response 200 {"data":{"id":12,"title":"new chapter yes","public":false,"blockIds":[]}}
+     * @response 404 {"message":"The selected chapter id is invalid.","errors":{"chapter_id":["The selected chapter id is invalid."]}}
      */
-    public function show(Chapter $chapter)
+    public function show(ShowChapterRequest $request)
     {
+        $chapter = Chapter::where('chapter_id', $request->chapter_id)->first();
+
         return new ChapterResource($chapter);
     }
 
     /**
      * Update the specified resource in storage.
-     * 
-     * @urlparam id integer required The ID of the chapter.
+     *
+     * @urlParam id integer required The ID of the chapter.
+     *
      * @bodyParam title string required The title of the chapter.
+     *
+     * @response 200
+     * @response 422 {"message":"The selected blockIds.0 is invalid.","errors":{"blockIds.0":["The selected blockIds.0 is invalid."]}}
+     * @response 422 {"message":"The block ids field must be an array.","errors":{"blockIds":["The block ids field must be an array."]}}
      */
     public function update(UpdateChapterRequest $request, Chapter $chapter)
     {
@@ -63,16 +91,25 @@ class ChapterController extends Controller
 
     /**
      * Deletes a chapter.
-     * 
-     * @urlparam id integer required The ID of the chapter.
+     *
+     * @urlParam id integer required The ID of the chapter.
+     *
      * @response 204
+     * @response 422 {"message":"The selected chapter id is invalid.","errors":{"chapter_id":["The selected chapter id is invalid."]}}
      */
-    public function destroy(int $id)
+    public function destroy(DeleteChapterRequest $request)
     {
-        $chapter = Chapter::find($id);
-        if ($chapter) {
+
+        DB::transaction(function () use ($request) {
+            $chapter = Chapter::where('chapter_id', $request->chapter_id)->first();
+
+            $cover = $chapter->cover;
+            $cover->removeChapter($chapter);
+            $cover->save();
+
             $chapter->delete();
-        }
+        });
+
         return response()->json(null, 204);
     }
 }

--- a/app/Http/Requests/Api/V1/DeleteChapterRequest.php
+++ b/app/Http/Requests/Api/V1/DeleteChapterRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteChapterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'chapter_id' => ['required', 'integer', 'exists:chapters,chapter_id'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge(['chapter_id' => $this->route('chapter')]);
+    }
+}

--- a/app/Http/Requests/Api/V1/ShowChapterRequest.php
+++ b/app/Http/Requests/Api/V1/ShowChapterRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowChapterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'chapter_id' => ['required', 'integer', 'exists:chapters,chapter_id'],
+        ];
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge(['chapter_id' => $this->route('chapter')]);
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateChapterRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateChapterRequest.php
@@ -24,13 +24,17 @@ class UpdateChapterRequest extends FormRequest
         $method = $this->method();
         if ($method === 'PUT') {
             return [
-                'title' => ['required'],
-                'coverId' => ['required', 'integer', 'exists:covers,cover_id']
+                'title' => ['required', 'string'],
+                'public' => ['required', 'boolean'],
+                'blockIds' => ['required', 'array'],
+                'blockIds.*' => ['required', 'string', 'exists:blocks,block_nanoid_10'],
             ];
         } else {
             return [
-                'title' => ['sometimes', 'required'],
-                'coverId' => ['sometimes', 'required', 'integer', 'exists:covers,cover_id']
+                'title' => ['sometimes', 'required', 'string'],
+                'public' => ['sometimes', 'required', 'boolean'],
+                'blockIds' => ['sometimes', 'required', 'array'],
+                'blockIds.*' => ['sometimes', 'required', 'string', 'exists:blocks,block_nanoid_10'],
             ];
         }
 
@@ -38,9 +42,9 @@ class UpdateChapterRequest extends FormRequest
 
     protected function passedValidation()
     {
-        if ($this->coverId) {
+        if ($this->blockIds) {
             $this->merge([
-                'cover_id' => $this->coverId
+                'block_ids' => $this->blockIds,
             ]);
         }
     }

--- a/app/Http/Resources/V1/ChapterResource.php
+++ b/app/Http/Resources/V1/ChapterResource.php
@@ -17,7 +17,8 @@ class ChapterResource extends JsonResource
         return [
             'id' => $this->chapter_id,
             'title' => $this->title,
-            'coverId' => $this->cover_id,
+            'public' => $this->public,
+            'blockIds' => $this->block_ids,
         ];
     }
 }

--- a/app/Models/Chapter.php
+++ b/app/Models/Chapter.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Chapter extends Model
 {
@@ -15,11 +15,11 @@ class Chapter extends Model
     protected $fillable = [
         'cover_id',
         'title',
-        'block_ids'
+        'block_ids',
     ];
 
     protected $casts = [
-        'block_ids'=> 'array', // 'block_ids' is a JSON array
+        'block_ids' => 'array', // 'block_ids' is a JSON array
         'public' => 'boolean',
         'word_count' => 'integer',
         'published_at' => 'datetime',
@@ -28,6 +28,16 @@ class Chapter extends Model
     protected $dates = [
         'created_at',
         'updated_at',
-        'published_at'
+        'published_at',
     ];
+
+    protected $attributes = [
+        'public' => false,
+        'block_ids' => '[]',
+    ];
+
+    public function cover(): BelongsTo
+    {
+        return $this->belongsTo(Cover::class, 'cover_id');
+    }
 }

--- a/database/migrations/2024_06_24_055734_change_cover_chapters_relationship_to_json.php
+++ b/database/migrations/2024_06_24_055734_change_cover_chapters_relationship_to_json.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE covers ADD COLUMN chapter_ids JSON NOT NULL DEFAULT (JSON_ARRAY()) AFTER lang_id');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE covers DROP COLUMN chapter_ids');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,9 @@
 <?php
 
 use App\Http\Controllers\Api\V1\BlocksApi;
+use App\Http\Controllers\Api\V1\ChapterController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Api\V1\ChapterController;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,13 +17,13 @@ use App\Http\Controllers\Api\V1\ChapterController;
 */
 
 Route::middleware('auth:sanctum')->group(function () {
-    Route::get('/user',  function (Request $request) {
+    Route::get('/user', function (Request $request) {
         return $request->user();
     });
-    
-    Route::group(['prefix' => 'v1'],  function () {
-        Route::apiResource('chapters', ChapterController::class);
-        Route::post('chapters/{chapterId}/blocks', [BlocksApi::class, 'bulkStore']);
-        Route::get('chapters/{chapterId}/blocks', [BlocksApi::class, 'index']);
-    });
+
+});
+Route::group(['prefix' => 'v1'], function () {
+    Route::apiResource('chapters', ChapterController::class);
+    Route::post('chapters/{chapterId}/blocks', [BlocksApi::class, 'bulkStore']);
+    Route::get('chapters/{chapterId}/blocks', [BlocksApi::class, 'index']);
 });


### PR DESCRIPTION
closes #52 

- added chapterIds to `cover` entity
- reworked `Chapters` APIs
- Added response examples
- tested locally

Examples:

INDEX
```shell
curl localhost:8000/api/v1/chapters?coverId=1 -H "Content-Type: application/json" -H "Accept: applications/json"
```

GET
```shell
curl localhost:8000/api/v1/chapters/1 -H "Content-Type: application/json" -H "Accept: applications/json"
```

POST
```shell
curl localhost:8000/api/v1/chapters?coverId=1 -H "Content-Type: application/json" -H "Accept: applications/json" -d '{"title": "new chapter yes", "coverId": 1}'
```

PUT
```shell
curl -X PUT localhost:8000/api/v1/chapters/1 -H "Content-Type: application/json" -H "Accept: applications/json" -d '{"title": "new YAYA  yes", "public": true, "blockIds": ["abcdefghij"]}'
```


PATCH
```shell
curl -X PUT localhost:8000/api/v1/chapters/1 -H "Content-Type: application/json" -H "Accept: applications/json" -d '{"title": "new YAYA  yes"}'
```


DELETE
```shell
curl -X DELETE localhost:8000/api/v1/chapters/1 -H "Content-Type: application/json" -H "Accept: applications/json"
```